### PR TITLE
Trigger detail pipeline when hits.json updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,10 @@
 ## 資料流程
 
 ```
-runner.py  →  取得評級資料
+runner.py  →  取得評級資料（hits.json 有更新時自動執行 main.run_pipeline → company_details.json → company_details.xlsx）
    ├─ ok.json   （所有正常回應）
    ├─ hits.json （評級 A~K 的命中）
    └─ state.json（續跑進度）
-
-main.py    →  針對 hits.json 取公司詳細資訊 → company_details.json → company_details.xlsx
 ```
 
 > 所有檔案預設**讀寫於執行檔所在目錄**。打包後（.exe）亦相同：請把 `.exe` 與欲讀寫的 `.json` 放在**同一目錄**。
@@ -88,18 +86,15 @@ python runner.py --year 113 --sleep 0.1
 
 * `OK <統編> ... name_zh=<公司名稱>`：表示**正常回應**，寫入 `ok.json`。
 * `HIT <統編> ... import=<代碼> export=<代碼>`：為**評級 A\~K 命中**，寫入 `hits.json`。
+  `runner.py` 會在 `hits.json` 有新增時自動產生/匯出 `company_details.json` 與 `company_details.xlsx`。
 
-### 2) 生成詳細資料並匯出 Excel
+### 2) （可選）重新生成詳細資料並匯出 Excel
+
+如需重新生成可手動執行：
 
 ```bash
 python main.py
 ```
-
-流程：
-
-1. 讀取 `hits.json`（若為空則不進行）。
-2. 針對每家公司抓取詳細資料 → 產生 `company_details.json`。
-3. 依固定欄位順序輸出 `company_details.xlsx`。
 
 ---
 

--- a/runner.py
+++ b/runner.py
@@ -35,6 +35,7 @@ from api_client import post_company_with_429_retry
 from parsing_utils import pick_year_row, is_A_to_K, row_is_normal, upsert_nested
     # 解析回應資料
 from pathlib import Path
+from main import run_pipeline
 
 def _interactive_args_if_needed() -> None:
     """
@@ -193,6 +194,10 @@ def main() -> None:
                         log.info(
                             f"HIT {vat}  year={args.year}  import={import_grade}  export={export_grade}"
                         )
+                        try:
+                            run_pipeline()
+                        except Exception as exc:
+                            log.error(f"run_pipeline failed: {exc!r}")
 
             processed += 1
 


### PR DESCRIPTION
## Summary
- run main pipeline automatically from runner whenever hits.json gains new entries
- document auto-triggered company detail generation and optional manual run

## Testing
- `python runner.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb4a0a0188328a82dcc8def34b54d