### PR TITLE
Automatically sync company details export

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,8 +93,8 @@ def run_pipeline() -> None:
     if last_pair:
         excel_last = _excel_last_pair(excel_path)
         if excel_last != last_pair:
-            print("company_details.json 與 company_details.xlsx 不同步，請先執行 export_company_details.py")
-            return
+            print("發現 company_details.json 與 company_details.xlsx 不同步，準備自動更新")
+            export_excel()
 
     hits_to_process = _slice_hits_after(input_path, last_pair)
     if not hits_to_process:


### PR DESCRIPTION
## Summary
- Automatically run `export_company_details` when `company_details.json` and `company_details.xlsx` are out of sync
- Update console message to indicate auto update

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68adc483ac288328975665407f43ed40