### PR TITLE
Fix exporter path for frozen executables

### DIFF
--- a/fbfh_trade/company/exporter.py
+++ b/fbfh_trade/company/exporter.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from fbfh_trade.persistence import get_app_dir
+
 try:
     # 優先使用 openpyxl 內建的非法字元正規表示式
     from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE  # type: ignore
@@ -21,7 +23,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 # ----------------------------
 # 常數與 I/O 路徑
 # ----------------------------
-BASE_DIR = Path(__file__).resolve().parents[2]
+BASE_DIR = get_app_dir()
 INPUT_JSON = BASE_DIR / "company_details.json"
 OUTPUT_XLSX = BASE_DIR / "company_details.xlsx"
 


### PR DESCRIPTION
## Summary
- Use `get_app_dir()` to resolve paths when running as a frozen executable so bundled data files are found next to the exe

## Testing
- `python -m py_compile fbfh_trade/company/exporter.py`
- ⚠️ `pip install openpyxl` (failed: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b0602d4c348328876d0b5147666f3c